### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/soetardjo9090/12ef2fba-b6d9-4e2c-b954-5a7b2596403c/c40df2ae-ed5b-42e9-acf8-14621ad6b87c/_apis/work/boardbadge/455e96ad-e6be-4514-976c-33de4732e74a)](https://dev.azure.com/soetardjo9090/12ef2fba-b6d9-4e2c-b954-5a7b2596403c/_boards/board/t/c40df2ae-ed5b-42e9-acf8-14621ad6b87c/Microsoft.RequirementCategory)
 # sumberkoding
 for people knowledge


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/soetardjo9090/12ef2fba-b6d9-4e2c-b954-5a7b2596403c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.